### PR TITLE
Bugfix/prohibit like node links

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -129,6 +129,8 @@ class Graph {
 
                 if (!source || !target) return;
 
+                if (source.nodeType === target.nodeType) return;
+
                 // source and target are different
                 if (source !== target) {
                     // remove edge between source and target (any order)

--- a/graph.js
+++ b/graph.js
@@ -71,9 +71,12 @@ class Graph {
         this.svg
             .on("mousedown", (event, d) => {
                 if (event.shiftKey) {
-                    const entityId = prompt("Enter entity type: ")
+                    const entityType = prompt("Enter entity type: ")
+                    if (entityType === null || entityType === "") {
+                        return;
+                    }
                     const pos = d3.pointer(event, graph.plot.node())
-                    const node = { id: ++this.nodeId, nodeType: "entity", "type": entityId, title: "", x: pos[0], y: pos[1], attributes: [{"key": "123", "value": "123", "type": "string"}]}
+                    const node = { id: ++this.nodeId, nodeType: "entity", "type": entityType, title: "", x: pos[0], y: pos[1], attributes: [{"key": "123", "value": "123", "type": "string"}]}
                     node.title = node.type + "-" + node.id
                     this.nodes.push(node);
                     this.updateNodes("entity");
@@ -81,6 +84,9 @@ class Graph {
 
                 if (event.ctrlKey) {
                     const docType = prompt("Enter document type: ")
+                    if (docType === null || docType === "") {
+                        return;
+                    }
                     const pos = d3.pointer(event, graph.plot.node())
                     const node = { id: ++this.nodeId, nodeType: "document", type: docType, title: "", x: pos[0]-this.consts.RECT_WIDTH/2, y: pos[1]-this.consts.RECT_HEIGHT/2, attributes:[{"key": "123", "value": "123", "type": "string"}, {"key": "abc", "value": "1", "type": "string"}]}
                     node.title = node.type + "-" + node.id


### PR DESCRIPTION
Prohibited doc-doc and entity-entity links
Fixed an issue with null type documents and entities spawning when 'Cancel' is selected on node creation prompt