### PR TITLE
Make toLiteGraph output correct json format for attributes

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -506,7 +506,7 @@ class Graph {
                 case 'float':
                     return /^[-+]?[0-9]*(\.[0-9]+)$/.test(val);
                 case 'boolean':
-                    return (val == 'true') || (val == 'false');
+                    return (val === 'true') || (val === 'false');
             }
             return true;
         }
@@ -641,6 +641,23 @@ class Graph {
     }
 
     formatAttributes(attributes) {
+        function convertStrToType(val, type) {
+            switch (type) {
+                case 'long':
+                case 'short':
+                case 'int':
+                case 'double':
+                    const numericVal = parseInt(val);
+                    return isNaN(numericVal) ? val : numericVal;
+                case 'float':
+                    const floatVal = parseFloat(val);
+                    return isNaN(floatVal) ? val : floatVal;
+                case 'boolean':
+                    return (val === 'true') || (val === 'false');
+            }
+            return val;
+        }
+
         const suffix = "Attributes";
         let attrMap = new Map();
         attributes.forEach(attr => {
@@ -649,7 +666,7 @@ class Graph {
             if (attrMap.has(attrType)) {
                 attrObj = attrMap.get(attrType);
             }
-            attrObj[attr.key] = attr.value;
+            attrObj[attr.key] = convertStrToType(attr.value, attr.type);
             attrMap.set(attrType, attrObj);
         });
         return Object.fromEntries(attrMap);

--- a/graph.js
+++ b/graph.js
@@ -617,18 +617,41 @@ class Graph {
             const target = edge.target;
             const document = source.nodeType === "document" ? source : target;
             const entity = source.nodeType === "entity" ? source : target;
-            return { edgeId: edge.id, documentId: document.id, documentType: document.type, entityId: entity.id, entityType: entity.type, attributes: edge.attributes };
+            return {
+                edgeId: edge.id,
+                documentId: document.id,
+                documentType: document.type,
+                entityId: entity.id,
+                entityType: entity.type,
+                attributes: edge.attributes
+            };
         });
         const documentsAndEntities = this.nodes.reduce((acc, node) => {
             if (node.nodeType === "document") {
-                acc.documents.push(node);
+                const doc = {
+                    documentId: node.id,
+                    documentType: node.type,
+                    attributes: node.attributes
+                };
+                acc.documents.push(doc);
             } else if (node.nodeType === "entity") {
-                acc.entities.push(node);
+                const ent = {
+                    entityId: node.id,
+                    entityType: node.type,
+                    attributes: node.attributes
+                };
+                acc.entities.push(ent);
             }
             return acc;
         }, { documents: [], entities: [] });
 
-        return new window.Blob([window.JSON.stringify({ "documents": documentsAndEntities.documents, "entities": documentsAndEntities.entities, "edges": saveEdges })], { type: "text/plain;charset=utf-8" });
+        return new window.Blob([window.JSON.stringify(
+            {
+                "documents": documentsAndEntities.documents,
+                "entities": documentsAndEntities.entities,
+                "edges": saveEdges
+            }
+            )], { type: "text/plain;charset=utf-8" });
     }
 }
 

--- a/graph.js
+++ b/graph.js
@@ -619,6 +619,21 @@ class Graph {
         this.update();
     }
 
+    formatAttributes(attributes) {
+        const suffix = "Attributes";
+        let attrMap = new Map();
+        attributes.forEach(attr => {
+            const attrType = attr.type + suffix;
+            let attrObj = {};
+            if (attrMap.has(attrType)) {
+                attrObj = attrMap.get(attrType);
+            }
+            attrObj[attr.key] = attr.value;
+            attrMap.set(attrType, attrObj);
+        });
+        return Object.fromEntries(attrMap);
+    }
+
     toLiteGraph() {
         const saveEdges = this.edges.map(edge => {
             const source = edge.source;
@@ -631,7 +646,7 @@ class Graph {
                 documentType: document.type,
                 entityId: entity.id,
                 entityType: entity.type,
-                attributes: edge.attributes
+                attributes: this.formatAttributes(edge.attributes)
             };
         });
         const documentsAndEntities = this.nodes.reduce((acc, node) => {
@@ -639,14 +654,14 @@ class Graph {
                 const doc = {
                     documentId: node.id,
                     documentType: node.type,
-                    attributes: node.attributes
+                    attributes: this.formatAttributes(node.attributes)
                 };
                 acc.documents.push(doc);
             } else if (node.nodeType === "entity") {
                 const ent = {
                     entityId: node.id,
                     entityType: node.type,
-                    attributes: node.attributes
+                    attributes: this.formatAttributes(node.attributes)
                 };
                 acc.entities.push(ent);
             }

--- a/graph.js
+++ b/graph.js
@@ -501,7 +501,7 @@ class Graph {
                 case 'long':
                 case 'short':
                 case 'int':
-                    return /^([0-9]*)$/.test(val);
+                    return /^([-+]?[0-9]*)$/.test(val);
                 case 'double':
                 case 'float':
                     return /^[-+]?[0-9]*(\.[0-9]+)$/.test(val);

--- a/graph.js
+++ b/graph.js
@@ -625,18 +625,41 @@ class Graph {
             const target = edge.target;
             const document = source.nodeType === "document" ? source : target;
             const entity = source.nodeType === "entity" ? source : target;
-            return { edgeId: edge.id, documentId: document.id, documentType: document.type, entityId: entity.id, entityType: entity.type, attributes: edge.attributes };
+            return {
+                edgeId: edge.id,
+                documentId: document.id,
+                documentType: document.type,
+                entityId: entity.id,
+                entityType: entity.type,
+                attributes: edge.attributes
+            };
         });
         const documentsAndEntities = this.nodes.reduce((acc, node) => {
             if (node.nodeType === "document") {
-                acc.documents.push(node);
+                const doc = {
+                    documentId: node.id,
+                    documentType: node.type,
+                    attributes: node.attributes
+                };
+                acc.documents.push(doc);
             } else if (node.nodeType === "entity") {
-                acc.entities.push(node);
+                const ent = {
+                    entityId: node.id,
+                    entityType: node.type,
+                    attributes: node.attributes
+                };
+                acc.entities.push(ent);
             }
             return acc;
         }, { documents: [], entities: [] });
 
-        return new window.Blob([window.JSON.stringify({ "documents": documentsAndEntities.documents, "entities": documentsAndEntities.entities, "edges": saveEdges })], { type: "text/plain;charset=utf-8" });
+        return new window.Blob([window.JSON.stringify(
+            {
+                "documents": documentsAndEntities.documents,
+                "entities": documentsAndEntities.entities,
+                "edges": saveEdges
+            }
+            )], { type: "text/plain;charset=utf-8" });
     }
 }
 

--- a/graph.js
+++ b/graph.js
@@ -611,6 +611,21 @@ class Graph {
         this.update();
     }
 
+    formatAttributes(attributes) {
+        const suffix = "Attributes";
+        let attrMap = new Map();
+        attributes.forEach(attr => {
+            const attrType = attr.type + suffix;
+            let attrObj = {};
+            if (attrMap.has(attrType)) {
+                attrObj = attrMap.get(attrType);
+            }
+            attrObj[attr.key] = attr.value;
+            attrMap.set(attrType, attrObj);
+        });
+        return Object.fromEntries(attrMap);
+    }
+
     toLiteGraph() {
         const saveEdges = this.edges.map(edge => {
             const source = edge.source;
@@ -623,7 +638,7 @@ class Graph {
                 documentType: document.type,
                 entityId: entity.id,
                 entityType: entity.type,
-                attributes: edge.attributes
+                attributes: this.formatAttributes(edge.attributes)
             };
         });
         const documentsAndEntities = this.nodes.reduce((acc, node) => {
@@ -631,14 +646,14 @@ class Graph {
                 const doc = {
                     documentId: node.id,
                     documentType: node.type,
-                    attributes: node.attributes
+                    attributes: this.formatAttributes(node.attributes)
                 };
                 acc.documents.push(doc);
             } else if (node.nodeType === "entity") {
                 const ent = {
                     entityId: node.id,
                     entityType: node.type,
-                    attributes: node.attributes
+                    attributes: this.formatAttributes(node.attributes)
                 };
                 acc.entities.push(ent);
             }

--- a/graph.js
+++ b/graph.js
@@ -495,6 +495,22 @@ class Graph {
 
     // Define the function to show node data
     showAttributeData(nodeOrEdge) {
+        function inputIsValid(key, val, type) {
+            if (!key || !val || !type) return false;
+            switch (type) {
+                case 'long':
+                case 'short':
+                case 'int':
+                case 'double':
+                    return /^([0-9]*)$/.test(val);
+                case 'float':
+                    return /^[-+]?[0-9]*(\.[0-9]+)$/.test(val);
+                case 'boolean':
+                    return (val == 'true') || (val == 'false');
+            }
+            return true;
+        }
+
         function refreshTable() {
             // Remove the old table if it exists
             d3.select('#node-attribute-data').selectAll('*').remove();
@@ -541,30 +557,34 @@ class Graph {
             });
 
             // Add button row
-// Add button row
             const buttonRow = table.append('tr');
+            let newKey = '';
+            let newValue = '';
+            let newType = '';
             buttonRow.append('td').append('input')
                 .attr('type', 'text')
                 .attr('name', 'key')
                 .attr('placeholder', 'Enter key')
                 .on('input', function() {
-                    const newKey = this.value;
-                    const newValue = buttonRow.select('input[type="text"][name="value"]:first-child').property('value');
-                    const newType = buttonRow.select('select[name="type"]').property('value');
+                    newKey = this.value;
+                    newValue = buttonRow.select('input[type="text"][name="value"]:first-child').property('value');
+                    newType = buttonRow.select('select[name="type"]').property('value');
                     const addButton = buttonRow.select('button');
-                    addButton.property('disabled', !newKey || !newValue || !newType);
+                    addButton.property('disabled', !inputIsValid(newKey, newValue, newType));
                 });
+
             buttonRow.append('td').append('input')
                 .attr('type', 'text')
                 .attr('name', 'value')
                 .attr('placeholder', 'Enter value')
                 .on('input', function() {
-                    const newValue = this.value;
+                    newValue = this.value;
                     const addButton = buttonRow.select('button');
-                    const newKey = buttonRow.select('input[type="text"][name="key"]:first-child').property('value');
-                    const newType = buttonRow.select('select[name="type"]').property('value');
-                    addButton.property('disabled', !newKey || !newValue || !newType);
+                    newKey = buttonRow.select('input[type="text"][name="key"]:first-child').property('value');
+                    newType = buttonRow.select('select[name="type"]').property('value');
+                    addButton.property('disabled', !inputIsValid(newKey, newValue, newType));
                 });
+
             buttonRow.append('td').append('select')
                 .attr('name', 'type')
                 .selectAll('option')
@@ -572,6 +592,7 @@ class Graph {
                 .enter()
                 .append('option')
                 .text(function(d) { return d; });
+
             buttonRow.append('td').append('button').text('+')
                 .attr('disabled', true)
                 .on('click', function() {

--- a/graph.js
+++ b/graph.js
@@ -632,8 +632,11 @@ class Graph {
             const target = edge.target;
             const document = source.nodeType === "document" ? source : target;
             const entity = source.nodeType === "entity" ? source : target;
+            const eid = this.edgeId(edge);
             return {
-                edgeId: edge.id,
+                edgeId: eid,
+                edgeType: document.type + '-' + entity.type,
+                label: document.type + '-' + entity.type + eid,
                 documentId: document.id,
                 documentType: document.type,
                 entityId: entity.id,
@@ -646,6 +649,7 @@ class Graph {
                 const doc = {
                     documentId: node.id,
                     documentType: node.type,
+                    label: node.type + node.id,
                     attributes: this.formatAttributes(node.attributes)
                 };
                 acc.documents.push(doc);
@@ -653,7 +657,9 @@ class Graph {
                 const ent = {
                     entityId: node.id,
                     entityType: node.type,
-                    attributes: this.formatAttributes(node.attributes)
+                    label: node.type + node.id,
+                    attributes: this.formatAttributes(node.attributes),
+                    records: []
                 };
                 acc.entities.push(ent);
             }

--- a/graph.js
+++ b/graph.js
@@ -501,8 +501,8 @@ class Graph {
                 case 'long':
                 case 'short':
                 case 'int':
-                case 'double':
                     return /^([0-9]*)$/.test(val);
+                case 'double':
                 case 'float':
                     return /^[-+]?[0-9]*(\.[0-9]+)$/.test(val);
                 case 'boolean':
@@ -580,8 +580,6 @@ class Graph {
                 .on('input', function() {
                     newValue = this.value;
                     const addButton = buttonRow.select('button');
-                    newKey = buttonRow.select('input[type="text"][name="key"]:first-child').property('value');
-                    newType = buttonRow.select('select[name="type"]').property('value');
                     addButton.property('disabled', !inputIsValid(newKey, newValue, newType));
                 });
 
@@ -592,6 +590,13 @@ class Graph {
                 .enter()
                 .append('option')
                 .text(function(d) { return d; });
+
+            buttonRow.select('select[name="type"]')
+                .on('click', function() {
+                    const addButton = buttonRow.select('button');
+                    newType = this.value;
+                    addButton.property('disabled', !inputIsValid(newKey, newValue, newType));
+                });
 
             buttonRow.append('td').append('button').text('+')
                 .attr('disabled', true)
@@ -646,14 +651,14 @@ class Graph {
                 case 'long':
                 case 'short':
                 case 'int':
-                case 'double':
                     const numericVal = parseInt(val);
                     return isNaN(numericVal) ? val : numericVal;
+                case 'double':
                 case 'float':
                     const floatVal = parseFloat(val);
                     return isNaN(floatVal) ? val : floatVal;
                 case 'boolean':
-                    return (val === 'true') || (val === 'false');
+                    return val === 'true' ? true : val === 'false' ? false : val;
             }
             return val;
         }

--- a/graph.js
+++ b/graph.js
@@ -640,8 +640,11 @@ class Graph {
             const target = edge.target;
             const document = source.nodeType === "document" ? source : target;
             const entity = source.nodeType === "entity" ? source : target;
+            const eid = this.edgeId(edge);
             return {
-                edgeId: edge.id,
+                edgeId: eid,
+                edgeType: document.type + '-' + entity.type,
+                label: document.type + '-' + entity.type + eid,
                 documentId: document.id,
                 documentType: document.type,
                 entityId: entity.id,
@@ -654,6 +657,7 @@ class Graph {
                 const doc = {
                     documentId: node.id,
                     documentType: node.type,
+                    label: node.type + node.id,
                     attributes: this.formatAttributes(node.attributes)
                 };
                 acc.documents.push(doc);
@@ -661,7 +665,9 @@ class Graph {
                 const ent = {
                     entityId: node.id,
                     entityType: node.type,
-                    attributes: this.formatAttributes(node.attributes)
+                    label: node.type + node.id,
+                    attributes: this.formatAttributes(node.attributes),
+                    records: []
                 };
                 acc.entities.push(ent);
             }


### PR DESCRIPTION
- Outputs attributes in LiteGraph json format.
- Adds some client-side input validation for attributes e.g. user can't add attribute if the selected type is numeric and the value contains non-numeric characters. For boolean type, only 'true' and 'false' are accepted.
- Outputs numeric and boolean attributes as the correct type i.e. without the quote marks. The other types are currently outputted as string (with quote marks).

Example output (manually prettified):
```
{
  "documents": [
    {
      "documentId": 1,
      "documentType": "icij",
      "label": "icij1",
      "attributes": {
        "stringAttributes": {
          "123": "123",
          "abc": "1"
        },
        "intAttributes": {
          "year": 2023
        },
        "booleanAttributes": {
          "isIncorporated": true,
          "hasIntermediary": false
        }
      }
    }
  ],
  "entities": [
    {
      "entityId": 3,
      "entityType": "address",
      "label": "address3",
      "attributes": {
        "stringAttributes": {
          "123": "123"
        }
      },
      "records": []
    }
  ],
  "edges": [
    {
      "edgeId": "1+3",
      "edgeType": "icij-address",
      "label": "icij-address1+3",
      "documentId": 1,
      "documentType": "icij",
      "entityId": 3,
      "entityType": "address",
      "attributes": {
        "doubleAttributes": {
          "avsdad": 5.1234
        }
      }
    }
  ]
}
```