### PR TITLE
Bugfix/fix sticky entities

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -80,6 +80,7 @@ class Graph {
                     node.title = node.type + "-" + node.id
                     this.nodes.push(node);
                     this.updateNodes("entity");
+                    event.stopImmediatePropagation();
                 }
 
                 if (event.ctrlKey) {
@@ -92,6 +93,7 @@ class Graph {
                     node.title = node.type + "-" + node.id
                     this.nodes.push(node);
                     this.updateNodes("document");
+                    event.stopImmediatePropagation();
                 }
             })
             .on('click', () => {


### PR DESCRIPTION
Newly created entities "stuck" to the mouse cursor because some other mousedown events were being triggered (dragging, node selection). This 2-liner fix prevents any other listener from being triggered by this event.

Note: Documents were not sticking to the cursor because there seems to be smth special about ctrl-click which unsticks the node. Any other key would result in stickiness.

Closes #5 